### PR TITLE
Add local folder sync for work sheets

### DIFF
--- a/Commands/Worksheet/RemoveWorksheetCommand.cs
+++ b/Commands/Worksheet/RemoveWorksheetCommand.cs
@@ -212,8 +212,10 @@ namespace Snowflake.Powershell
                 {
                     logger.Info("Deleting {0}", worksheet);
                     loggerConsole.Trace("Deleting Worksheet {0} ({1})", worksheet.WorksheetName, worksheet.WorksheetID);
+                    
                      if(!String.IsNullOrEmpty(worksheet.LocalPath))
                     {
+                          loggerConsole.Trace("Deleting Worksheet {0} ({1}) from file", worksheet.WorksheetName, worksheet.WorksheetID);
                           FileIOHelper.DeleteFile(worksheet.LocalPath);
                     }
                     // Delete the Worksheet

--- a/Commands/Worksheet/RemoveWorksheetCommand.cs
+++ b/Commands/Worksheet/RemoveWorksheetCommand.cs
@@ -212,7 +212,10 @@ namespace Snowflake.Powershell
                 {
                     logger.Info("Deleting {0}", worksheet);
                     loggerConsole.Trace("Deleting Worksheet {0} ({1})", worksheet.WorksheetName, worksheet.WorksheetID);
-                    
+                     if(!String.IsNullOrEmpty(worksheet.LocalPath))
+                    {
+                          FileIOHelper.DeleteFile(worksheet.LocalPath);
+                    }
                     // Delete the Worksheet
                     string worksheetDeleteApiResult = SnowflakeDriver.DeleteWorksheet(this.AuthContext, worksheet.WorksheetID);
                     if (worksheetDeleteApiResult.Length == 0)

--- a/DataObjects/Config.cs
+++ b/DataObjects/Config.cs
@@ -1,0 +1,17 @@
+namespace Snowflake.Powershell
+{
+    public class Config
+    {
+        public bool DebugEnabled {get;set;}
+        public LocalPath LocalPath {get;set;}
+    }
+
+    public class LocalPath
+    {
+       public string Worksheet {get;set;}
+       public string Dashboard {get;set;}
+       public string Filter {get;set;}
+       public string Folder {get;set;}
+       public string QueryProfile {get;set;}
+    }
+}

--- a/DataObjects/Worksheet.cs
+++ b/DataObjects/Worksheet.cs
@@ -96,9 +96,12 @@ namespace Snowflake.Powershell
             this.FolderName = String.Empty;
             
             JObject localConfig = FileIOHelper.LoadConfig();
-            string worksheetLocalPath = JSONHelper.getStringValueFromJToken(localConfig["LocalPath"], "Worksheet");
+            string worksheetLocalPath = JSONHelper.getStringValueFromJToken(localConfig, "Worksheet");
             if(!String.IsNullOrEmpty(worksheetLocalPath)){
-                this.LocalPath = String.Concat(worksheetLocalPath, this._FileSystemSafeName);
+                this.LocalPath = 
+                    worksheetLocalPath + "/" +
+                    String.Format("Worksheet.{0}.{1}.{2}.json", FileIOHelper.GetFileSystemSafeString(this.AccountName), FileIOHelper.GetShortenedEntityNameForFileSystem(this.WorksheetName, 30), FileIOHelper.GetFileSystemSafeString(this.WorksheetID));
+                
 
             }
         

--- a/DataObjects/Worksheet.cs
+++ b/DataObjects/Worksheet.cs
@@ -95,8 +95,8 @@ namespace Snowflake.Powershell
             this.Query = String.Empty;
             this.FolderName = String.Empty;
             
-            JObject localPathObject = FileIOHelper.LoadLocalPathSettings();
-            string worksheetLocalPath = JSONHelper.getStringValueFromJToken(localPathObject, "Worksheet");
+            JObject localConfig = FileIOHelper.LoadConfig();
+            string worksheetLocalPath = JSONHelper.getStringValueFromJToken(localConfig["LocalPath"], "Worksheet");
             if(!String.IsNullOrEmpty(worksheetLocalPath)){
                 this.LocalPath = String.Concat(worksheetLocalPath, this._FileSystemSafeName);
 

--- a/DataObjects/Worksheet.cs
+++ b/DataObjects/Worksheet.cs
@@ -30,6 +30,7 @@ namespace Snowflake.Powershell
         public string URL { get; set; }
         public string WorksheetID { get; set; }
         public string WorksheetName { get; set; }
+        public string LocalPath {get;set;}
 
         // Worksheet Dates
         public DateTime StartedUtc { get; set; }
@@ -90,7 +91,7 @@ namespace Snowflake.Powershell
 
             this.WorksheetID = JSONHelper.getStringValueFromJToken(entityObject, "entityId");
             this.WorksheetName = JSONHelper.getStringValueFromJToken(entityObject["info"], "name");
-
+            this.LocalPath = String.Empty;
             this.Query = String.Empty;
             this.FolderName = String.Empty;
 
@@ -213,7 +214,7 @@ namespace Snowflake.Powershell
             this.Region = authContext.Region;
 
             this.WorksheetID = worksheetID;
-
+            this.LocalPath = String.Empty;
             this.Query = String.Empty;
             this.FolderName = String.Empty;
 

--- a/DataObjects/Worksheet.cs
+++ b/DataObjects/Worksheet.cs
@@ -91,9 +91,17 @@ namespace Snowflake.Powershell
 
             this.WorksheetID = JSONHelper.getStringValueFromJToken(entityObject, "entityId");
             this.WorksheetName = JSONHelper.getStringValueFromJToken(entityObject["info"], "name");
-            this.LocalPath = String.Empty;
+            
             this.Query = String.Empty;
             this.FolderName = String.Empty;
+            
+            JObject localPathObject = FileIOHelper.LoadLocalPathSettings();
+            string worksheetLocalPath = JSONHelper.getStringValueFromJToken(localPathObject, "Worksheet");
+            if(!String.IsNullOrEmpty(worksheetLocalPath)){
+                this.LocalPath = String.Concat(worksheetLocalPath, this._FileSystemSafeName);
+
+            }
+        
 
             JObject entityDetailObject = (JObject)JSONHelper.getJTokenValueFromJToken(queriesObject, this.WorksheetID);
             if (entityDetailObject != null)

--- a/Helpers/FileIOHelper.cs
+++ b/Helpers/FileIOHelper.cs
@@ -380,13 +380,13 @@ namespace Snowflake.Powershell
 
             return null;
         }
-        public static JObject LoadLocalPathSettings(){
+        public static JObject LoadConfig(){
             try{
-            LocalPath config = new ConfigurationBuilder()
+            Config config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("appsettings.json")
                     .Build()
-                    .Get<LocalPath>();
+                    .Get<Config>();
             return JObject.FromObject(config);
             }
             catch(Exception ex){
@@ -402,18 +402,19 @@ namespace Snowflake.Powershell
                     string folderPath = Path.GetDirectoryName(jsonFilePath);
                     string appSettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
                     string settingsToWrite;
-                    LocalPath objLocalPath;
+                    Config config;
                     string obj = objectToWrite.GetType().Name;
                     if (File.Exists(appSettingsPath))
                     {  
-                       objLocalPath = LoadLocalPathSettings().ToObject<LocalPath>();
+                       config = LoadConfig().ToObject<Config>();
                     }
                     else{
-                        objLocalPath = new LocalPath();
+                        config = new Config();
                     }
-                    object boxed = RuntimeHelpers.GetObjectValue(objLocalPath);
-                    objLocalPath.GetType().GetProperty(obj).SetValue(boxed, folderPath);
-                    settingsToWrite = JsonConvert.SerializeObject(objLocalPath);
+
+                    object boxed = RuntimeHelpers.GetObjectValue(config.LocalPath);
+                    config.LocalPath.GetType().GetProperty(obj).SetValue(boxed, folderPath);
+                    settingsToWrite = JsonConvert.SerializeObject(config);
                     logger.Info("Writing LocalPath settings for object {0} to appsettings.json",obj);
                     File.WriteAllText(appSettingsPath, settingsToWrite);
             }

--- a/Helpers/FileIOHelper.cs
+++ b/Helpers/FileIOHelper.cs
@@ -380,6 +380,14 @@ namespace Snowflake.Powershell
 
             return null;
         }
+        public static JObject LoadLocalPathSettings(){
+            LocalPath config = new ConfigurationBuilder()
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+                    .AddJsonFile("appsettings.json")
+                    .Build()
+                    .Get<LocalPath>();
+            return JObject.FromObject(config);
+        }
 
 
         public static bool WriteLocalPathToSettings (object objectToWrite, string jsonFilePath){
@@ -390,12 +398,8 @@ namespace Snowflake.Powershell
                     LocalPath objLocalPath;
                     string obj = objectToWrite.GetType().Name;
                     if (File.Exists(appSettingsPath))
-                    {
-                        objLocalPath = new ConfigurationBuilder()
-                        .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-                        .AddJsonFile("appsettings.json")
-                        .Build()
-                        .Get<LocalPath>();
+                    {  
+                       objLocalPath = LoadLocalPathSettings().ToObject<LocalPath>();
                     }
                     else{
                         objLocalPath = new LocalPath();

--- a/Helpers/FileIOHelper.cs
+++ b/Helpers/FileIOHelper.cs
@@ -383,7 +383,7 @@ namespace Snowflake.Powershell
         public static JObject LoadLocalPathSettings(){
             try{
             LocalPath config = new ConfigurationBuilder()
-                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+                .SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("appsettings.json")
                     .Build()
                     .Get<LocalPath>();
@@ -400,7 +400,7 @@ namespace Snowflake.Powershell
         public static bool WriteLocalPathToSettings (object objectToWrite, string jsonFilePath){
             try{
                     string folderPath = Path.GetDirectoryName(jsonFilePath);
-                    string appSettingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
+                    string appSettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
                     string settingsToWrite;
                     LocalPath objLocalPath;
                     string obj = objectToWrite.GetType().Name;

--- a/Helpers/FileIOHelper.cs
+++ b/Helpers/FileIOHelper.cs
@@ -382,11 +382,11 @@ namespace Snowflake.Powershell
         }
         public static JObject LoadConfig(){
             try{
-            Config config = new ConfigurationBuilder()
+            LocalPath config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                     .AddJsonFile("appsettings.json")
                     .Build()
-                    .Get<Config>();
+                    .Get<LocalPath>();
             return JObject.FromObject(config);
             }
             catch(Exception ex){
@@ -402,18 +402,18 @@ namespace Snowflake.Powershell
                     string folderPath = Path.GetDirectoryName(jsonFilePath);
                     string appSettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
                     string settingsToWrite;
-                    Config config;
+                    LocalPath config;
                     string obj = objectToWrite.GetType().Name;
                     if (File.Exists(appSettingsPath))
                     {  
-                       config = LoadConfig().ToObject<Config>();
+                       config = LoadConfig().ToObject<LocalPath>();
                     }
                     else{
-                        config = new Config();
+                        config = new LocalPath();
                     }
 
-                    object boxed = RuntimeHelpers.GetObjectValue(config.LocalPath);
-                    config.LocalPath.GetType().GetProperty(obj).SetValue(boxed, folderPath);
+                    object boxed = RuntimeHelpers.GetObjectValue(config);
+                    config.GetType().GetProperty(obj).SetValue(boxed, folderPath);
                     settingsToWrite = JsonConvert.SerializeObject(config);
                     logger.Info("Writing LocalPath settings for object {0} to appsettings.json",obj);
                     File.WriteAllText(appSettingsPath, settingsToWrite);

--- a/Helpers/FileIOHelper.cs
+++ b/Helpers/FileIOHelper.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace Snowflake.Powershell
 {
@@ -299,6 +300,8 @@ namespace Snowflake.Powershell
             {
                 try
                 {
+                    object boxedObject = RuntimeHelpers.GetObjectValue(objectToWrite);
+                    objectToWrite.GetType().GetProperty("LocalPath").SetValue(boxedObject, jsonFilePath);
                     logger.Info("Writing object {0} to file {1}", objectToWrite.GetType().Name, jsonFilePath);
 
                     using (StreamWriter sw = File.CreateText(jsonFilePath))

--- a/Helpers/FileIOHelper.cs
+++ b/Helpers/FileIOHelper.cs
@@ -381,12 +381,19 @@ namespace Snowflake.Powershell
             return null;
         }
         public static JObject LoadLocalPathSettings(){
+            try{
             LocalPath config = new ConfigurationBuilder()
                 .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
                     .AddJsonFile("appsettings.json")
                     .Build()
                     .Get<LocalPath>();
             return JObject.FromObject(config);
+            }
+            catch(Exception ex){
+                logger.Error("Unable to write load configuration");
+                logger.Error(ex);
+            }
+            return null;
         }
 
 

--- a/SnowflakePS.csproj
+++ b/SnowflakePS.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Add local folder sync for worksheets to enable action done in remote(snowflake) to also occur on local development
-  Added Config Class for LocalPathSettings
-  Updated FileIoHelper to include writeLocalPathToSettings, thus dynamically. creating a config file 
-  Updated  Worksheet data object to ensure Get_SFWorkSheets add local path from the config file created when the command is called.
-  Updated  RemoveWorksheet such that if Remove SFWorksheet is called, the local file is also removed
