### PR TITLE
Update login method as Snowflake changed the OAuth response

### DIFF
--- a/SnowflakePS.csproj
+++ b/SnowflakePS.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>SnowflakePS</AssemblyName>
     <RootNamespace>Snowflake.Powershell</RootNamespace>
 
-    <Version>2023.2.8.0</Version>
-    <FileVersion>2023.2.8.0</FileVersion>
-    <AssemblyVersion>2023.2.8.0</AssemblyVersion>
+    <Version>2024.1.0.0</Version>
+    <FileVersion>2024.1.0.0</FileVersion>
+    <AssemblyVersion>2024.1.0.0</AssemblyVersion>
     <Authors>Daniel Odievich, Ryan Bacastow, Michael Ybarra</Authors>
     <Company>Snowflake Computing</Company>
     <Product>Snowflake Snowsight Extensions</Product>


### PR DESCRIPTION
1. Allow redirects from GET requests
2. Get cookies from all responses
3. Workaround for the issue that the API now returns the client_id in the URL, and the apiGET function doesn't return the URL. So we need to return the final redirected URL as the result for
`start-oauth/snowflake`.

Tested username+password and SSO.

Fixes #45 